### PR TITLE
Allow servers running MySQL below version 5.5 to still use Budabot

### DIFF
--- a/core/DB.class.php
+++ b/core/DB.class.php
@@ -48,7 +48,14 @@ class DB {
 			$this->sql->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			$this->exec("SET sql_mode = 'TRADITIONAL,NO_BACKSLASH_ESCAPES'");
 			$this->exec("SET time_zone = '+00:00'");
-			$this->exec("SET default_storage_engine = MyISAM");
+                        
+			$mysqlVersion = $this->sql->getAttribute(PDO::ATTR_SERVER_VERSION);
+
+                        if (version_compare($mysqlVersion,  "5.5") >= 0) {
+                                $this->exec("SET default_storage_engine = MyISAM");
+                        } else if (version_compare($mysqlVersion,  "5.5") == -1) {
+                                $this->exec("SET storage_engine = MyISAM");
+                        }
 		} else if ($this->type == self::SQLITE) {
 			if ($host == null || $host == "" || $host == "localhost") {
 				$dbName = "./data/$dbName";


### PR DESCRIPTION
After seeing http://www.budabot.com/forum/viewtopic.php?f=5&t=1263 and currently being unable to upgrade MySQL I looked into and didn't see anything that actually requires MySQL 5.5 so hopefully this can be included to allow people who are running legacy software and can't update MySQL to still run Budabot.