### PR TITLE
Fixed regex for bio command in ALIEN_MODULE

### DIFF
--- a/modules/ALIEN_MODULE/AlienBioController.class.php
+++ b/modules/ALIEN_MODULE/AlienBioController.class.php
@@ -77,7 +77,7 @@ class AlienBioController {
 		$bios = explode("*", preg_replace("/> *</", ">*<", $arr[1]));
 		$blob = '';
 		forEach ($bios as $bio) {
-			preg_match("/^${bio_regex}$/i", trim($bio), $arr2);
+			preg_match("|^${bio_regex}$|i", trim($bio), $arr2);
 			$highid = $arr2[2];
 			$ql = $arr2[3];
 			switch ($highid) {


### PR DESCRIPTION
!bio command was always returning Unknown due to recent changes to the format of the regex used to identify them.  Updated the regex to match the other regexes used throughout the bot.