### PR TITLE
Fix trickle stats for Sneak Attack

### DIFF
--- a/modules/TRICKLE_MODULE/trickle.sql
+++ b/modules/TRICKLE_MODULE/trickle.sql
@@ -20,7 +20,7 @@ INSERT INTO trickle (id, groupName, name, amountAgi, amountInt, amountPsy, amoun
 INSERT INTO trickle (id, groupName, name, amountAgi, amountInt, amountPsy, amountSta, amountStr, amountSen) VALUES (16, 'Melee Weapons', 'Melee. Init.', .1, .1, .2, 0, 0, .6);
 INSERT INTO trickle (id, groupName, name, amountAgi, amountInt, amountPsy, amountSta, amountStr, amountSen) VALUES (17, 'Melee Weapons', 'Physic. Init', .1, .1, .2, 0, 0, .6);
 
-INSERT INTO trickle (id, groupName, name, amountAgi, amountInt, amountPsy, amountSta, amountStr, amountSen) VALUES (18, 'Melee Specials', 'Sneak Atck', 0, 0, .2, 0, 0, .8);
+INSERT INTO trickle (id, groupName, name, amountAgi, amountInt, amountPsy, amountSta, amountStr, amountSen) VALUES (18, 'Melee Specials', 'Sneak Atck', .5, .3, 0, 0, 0, .2);
 INSERT INTO trickle (id, groupName, name, amountAgi, amountInt, amountPsy, amountSta, amountStr, amountSen) VALUES (19, 'Melee Specials', 'Brawling', 0, 0, 0, .4, .6, 0);
 INSERT INTO trickle (id, groupName, name, amountAgi, amountInt, amountPsy, amountSta, amountStr, amountSen) VALUES (20, 'Melee Specials', 'Fast Attack', .6, 0, 0, 0, 0, .4);
 INSERT INTO trickle (id, groupName, name, amountAgi, amountInt, amountPsy, amountSta, amountStr, amountSen) VALUES (21, 'Melee Specials', 'Dimach', 0, 0, .2, 0, 0, .8);


### PR DESCRIPTION
Trickle stats are actually displayed wrong in the AO client (confirmed by GM Nirvelle [here](https://forums.anarchy-online.com/announcement.php?f=540)), the actual stats should be 50% Agility 30% Intelligence and 20% Sense.